### PR TITLE
Updated import statement typo.

### DIFF
--- a/process_http.py
+++ b/process_http.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-import gettor.http2
+import gettor.http
 
 
 def main():
-    api = gettor.http2.HTTP('http.cfg')
+    api = gettor.http.HTTP('http.cfg')
     api.load_data()
     # api.run()
     api.build()


### PR DESCRIPTION
Wrongly imported 'http2.py' instead of 'http.py'. Fixed.